### PR TITLE
Start analyzing functions and closures.  Update dependency on Phan.

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -1,0 +1,139 @@
+<?php
+
+use \Phan\Issue;
+
+/**
+ * This configuration will be read and overlayed on top of the
+ * default configuration. Command line arguments will be applied
+ * after this file is read.
+ *
+ * @see src/Phan/Config.php
+ * See Config for all configurable options.
+ *
+ * A Note About Paths
+ * ==================
+ *
+ * Files referenced from this file should be defined as
+ *
+ * ```
+ *   Config::projectPath('relative_path/to/file')
+ * ```
+ *
+ * where the relative path is relative to the root of the
+ * project which is defined as either the working directory
+ * of the phan executable or a path passed in via the CLI
+ * '-d' flag.
+ */
+return [
+
+    // If true, missing properties will be created when
+    // they are first seen. If false, we'll report an
+    // error message.
+    "allow_missing_properties" => false,
+
+    // Allow null to be cast as any type and for any
+    // type to be cast to null.
+    "null_casts_as_any_type" => false,
+
+    // If enabled, scalars (int, float, bool, string, null)
+    // are treated as if they can cast to each other.
+    'scalar_implicit_cast' => false,
+
+    // If true, seemingly undeclared variables in the global
+    // scope will be ignored. This is useful for projects
+    // with complicated cross-file globals that you have no
+    // hope of fixing.
+    'ignore_undeclared_variables_in_global_scope' => false,
+
+    // Backwards Compatibility Checking
+    'backward_compatibility_checks' => false,
+
+    // If enabled, check all methods that override a
+    // parent method to make sure its signature is
+    // compatible with the parent's. This check
+    // can add quite a bit of time to the analysis.
+    'analyze_signature_compatibility' => true,
+
+    'check_docblock_signature_return_type_match' => true,
+    'check_docblock_signature_param_type_match' => true,
+    'prefer_narrowed_phpdoc_param_type' => true,
+
+    // Set to true in order to attempt to detect dead
+    // (unreferenced) code. Keep in mind that the
+    // results will only be a guess given that classes,
+    // properties, constants and methods can be referenced
+    // as variables (like `$class->$property` or
+    // `$class->$method()`) in ways that we're unable
+    // to make sense of.
+    'dead_code_detection' => true,
+
+    // Run a quick version of checks that takes less
+    // time
+    "quick_mode" => false,
+
+    // Enable or disable support for generic templated
+    // class types.
+    'generic_types_enabled' => true,
+
+    // By default, Phan will not analyze all node types
+    // in order to save time. If this config is set to true,
+    // Phan will dig deeper into the AST tree and do an
+    // analysis on all nodes, possibly finding more issues.
+    //
+    // See \Phan\Analysis::shouldVisit for the set of skipped
+    // nodes.
+    'should_visit_all_nodes' => true,
+
+    // The minimum severity level to report on. This can be
+    // set to Issue::SEVERITY_LOW, Issue::SEVERITY_NORMAL or
+    // Issue::SEVERITY_CRITICAL.
+    'minimum_severity' => Issue::SEVERITY_LOW,
+
+    // The number of processes to fork off during the analysis
+    // phase.
+    'processes' => 1,
+
+    // A list of directories that should be parsed for class and
+    // method information. After excluding the directories
+    // defined in exclude_analysis_directory_list, the remaining
+    // files will be statically analyzed for errors.
+    //
+    // Thus, both first-party and third-party code being used by
+    // your application should be included in this list.
+    'directory_list' => [
+        'src',
+        'vendor/etsy/phan/src',
+    ],
+
+    // List of case-insensitive file extensions supported by Phan.
+    // (e.g. php, html, htm)
+    'analyzed_file_extensions' => ['php'],
+
+    // A directory list that defines files that will be excluded
+    // from static analysis, but whose class and method
+    // information should be included.
+    //
+    // Generally, you'll want to include the directories for
+    // third-party code (such as "vendor/") in this list.
+    //
+    // n.b.: If you'd like to parse but not analyze 3rd
+    //       party code, directories containing that code
+    //       should be added to the `directory_list` as
+    //       to `exclude_analysis_directory_list`.
+    "exclude_analysis_directory_list" => [
+        'vendor',
+    ],
+
+    // A list of plugin files to execute
+    'plugins' => [
+        'vendor/etsy/phan/.phan/plugins/DemoPlugin.php',
+        'vendor/etsy/phan/.phan/plugins/DollarDollarPlugin.php',
+        // NOTE: src/Phan/Language/Internal/FunctionSignatureMap.php mixes value without key as return type with values having keys deliberately.
+        // '.phan/plugins/DuplicateArrayKeyPlugin.php',
+
+        // NOTE: This plugin only produces correct results when
+        //       Phan is run on a single core (-j1).
+        // '.phan/plugins/UnusedSuppressionPlugin.php',
+    ],
+
+];

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,6 @@
         }
     ],
     "require-dev": {
-        "etsy/phan": "~0.8"
+        "etsy/phan": "~0.9.3 || ~0.8.5"
     }
 }

--- a/src/UnusedVariablePlugin.php
+++ b/src/UnusedVariablePlugin.php
@@ -600,7 +600,8 @@ class UnusedVariableVisitor extends PluginAwareAnalysisVisitor {
         if (strpos($docComment, '@phan-unused-param') === false) {
             return true;
         }
-        if (preg_match('/@param[^$]*\$' . preg_quote($param, '/') . '\b.*@phan-unused-param\b/') > 0) {
+        $regex = '/@param[^$]*\$' . preg_quote($param, '/') . '\b.*@phan-unused-param\b/';
+        if (preg_match($regex, $docComment) > 0) {
             return false;
         }
         return true;

--- a/src/UnusedVariablePlugin.php
+++ b/src/UnusedVariablePlugin.php
@@ -197,6 +197,10 @@ class UnusedVariableVisitor extends PluginAwareAnalysisVisitor {
         }
 
         $name = $node->children['name'];
+        // e.g. $$x, ${42}
+        if (!is_string($name) || !$name) {
+            return;
+        }
 
         if (!isset($assignments[$name])) {
             return;
@@ -274,6 +278,9 @@ class UnusedVariableVisitor extends PluginAwareAnalysisVisitor {
             $var_node = $node->children['var'];
             if ($var_node->kind === \ast\AST_ARRAY) {
                 foreach ($var_node->children as $elem_node) {
+                    if ($elem_node === null) {
+                        continue;  // e.g. "list(, $x) = expr"
+                    }
                     assert($elem_node->kind === \ast\AST_ARRAY_ELEM);
                     $var_node = $elem_node->children['value'];
                     if ($var_node->kind !== \ast\AST_VAR) {
@@ -314,6 +321,9 @@ class UnusedVariableVisitor extends PluginAwareAnalysisVisitor {
             $this->parseExpr($this->references, $node, $instructionCount);
             if (isset($node->children['var']->children['name']) && !$loopFlag) {
                 $name = $node->children['var']->children['name'];
+                if (!is_string($name) || !$name) {
+                    return false;
+                }
                 $instructionCount++;
                 // If this is a ref, mark it as used
                 $ref = false;

--- a/src/UnusedVariablePlugin.php
+++ b/src/UnusedVariablePlugin.php
@@ -534,9 +534,10 @@ class UnusedVariableVisitor extends PluginAwareAnalysisVisitor {
                     if ($shouldWarn) {
                         $this->emitPluginIssue(
                             $this->code_base,
-                            $this->context,
+                            clone($this->context)->withLineNumberStart($data['line']),
                             'PhanPluginUnusedMethodArgument',
-                            "Parameter is never used: $".$param."."
+                            'Parameter is never used: ${PARAMETER}',
+                            [$param]
                         );
                     }
                 } else {
@@ -547,9 +548,10 @@ class UnusedVariableVisitor extends PluginAwareAnalysisVisitor {
                         if (isset($assignments[$param])) {
                             $this->emitPluginIssue(
                                 $this->code_base,
-                                $this->context,
+                                clone($this->context)->withLineNumberStart($data['line']),
                                 'PhanPluginUnnecessaryReference',
-                                "$".$pointer." (assigned on line ".$data['line'].") is a reference to $".$param.", but $".$param." is never used."
+                                '${VARIABLE} is a reference to ${PARAMETER}, but ${PARAMETER} is never used',
+                                [$pointer, $param, $param]
                             );
                         }
                     } else {
@@ -565,9 +567,10 @@ class UnusedVariableVisitor extends PluginAwareAnalysisVisitor {
                         if ($shouldWarn) {
                             $this->emitPluginIssue(
                                 $this->code_base,
-                                $this->context,
+                                clone($this->context)->withLineNumberStart($data['line']),
                                 'PhanPluginUnusedVariable',
-                                "Variable is never used: $".$param." assigned on line ".$data['line']."."
+                                'Variable is never used: ${VARIABLE}',
+                                [$param]
                             );
                         }
                     }

--- a/tests/expected/all_output.expected
+++ b/tests/expected/all_output.expected
@@ -16,3 +16,9 @@ src/000_all.php:438 PhanPluginUnusedMethodArgument Parameter is never used: $fif
 src/000_all.php:457 PhanPluginUnnecessaryReference $sixteen (assigned on line 459) is a reference to $seventeen, but $seventeen is never used.
 src/000_all.php:457 PhanPluginUnusedVariable Variable is never used: $sixteen assigned on line 461.
 src/000_all.php:493 PhanPluginUnnecessaryReference $eighteen (assigned on line 495) is a reference to $nineteen, but $nineteen is never used.
+src/001_func.php:6 PhanPluginUnusedVariable Variable is never used: $one assigned on line 7.
+src/001_func.php:6 PhanPluginUnusedVariable Variable is never used: $two assigned on line 8.
+src/001_func.php:25 PhanPluginUnusedMethodArgument Parameter is never used: $three.
+src/002_closure.php:6 PhanPluginUnusedVariable Variable is never used: $one assigned on line 7.
+src/002_closure.php:6 PhanPluginUnusedVariable Variable is never used: $two assigned on line 8.
+src/002_closure.php:24 PhanPluginUnusedMethodArgument Parameter is never used: $three.

--- a/tests/expected/all_output.expected
+++ b/tests/expected/all_output.expected
@@ -1,24 +1,24 @@
-src/000_all.php:4 PhanPluginUnusedVariable Variable is never used: $one assigned on line 5.
-src/000_all.php:4 PhanPluginUnusedVariable Variable is never used: $two assigned on line 6.
-src/000_all.php:27 PhanPluginUnusedMethodArgument Parameter is never used: $three.
-src/000_all.php:49 PhanPluginUnusedVariable Variable is never used: $four assigned on line 54.
-src/000_all.php:63 PhanPluginUnusedVariable Variable is never used: $five assigned on line 68.
-src/000_all.php:117 PhanPluginUnusedVariable Variable is never used: $six assigned on line 124.
-src/000_all.php:149 PhanPluginUnusedVariable Variable is never used: $seven assigned on line 156.
-src/000_all.php:164 PhanPluginUnusedVariable Variable is never used: $eight assigned on line 167.
-src/000_all.php:198 PhanPluginUnusedVariable Variable is never used: $nine assigned on line 207.
-src/000_all.php:245 PhanPluginUnusedVariable Variable is never used: $ten assigned on line 251.
-src/000_all.php:267 PhanPluginUnusedVariable Variable is never used: $eleven assigned on line 273.
-src/000_all.php:289 PhanPluginUnusedVariable Variable is never used: $twelwe assigned on line 295.
-src/000_all.php:311 PhanPluginUnusedVariable Variable is never used: $thirteen assigned on line 318.
-src/000_all.php:415 PhanPluginUnusedVariable Variable is never used: $fourteen assigned on line 417.
-src/000_all.php:438 PhanPluginUnusedMethodArgument Parameter is never used: $fifteen.
-src/000_all.php:457 PhanPluginUnnecessaryReference $sixteen (assigned on line 459) is a reference to $seventeen, but $seventeen is never used.
-src/000_all.php:457 PhanPluginUnusedVariable Variable is never used: $sixteen assigned on line 461.
-src/000_all.php:493 PhanPluginUnnecessaryReference $eighteen (assigned on line 495) is a reference to $nineteen, but $nineteen is never used.
-src/001_func.php:6 PhanPluginUnusedVariable Variable is never used: $one assigned on line 7.
-src/001_func.php:6 PhanPluginUnusedVariable Variable is never used: $two assigned on line 8.
-src/001_func.php:25 PhanPluginUnusedMethodArgument Parameter is never used: $three.
-src/002_closure.php:6 PhanPluginUnusedVariable Variable is never used: $one assigned on line 7.
-src/002_closure.php:6 PhanPluginUnusedVariable Variable is never used: $two assigned on line 8.
-src/002_closure.php:24 PhanPluginUnusedMethodArgument Parameter is never used: $three.
+src/000_all.php:5 PhanPluginUnusedVariable Variable is never used: $one
+src/000_all.php:6 PhanPluginUnusedVariable Variable is never used: $two
+src/000_all.php:27 PhanPluginUnusedMethodArgument Parameter is never used: $three
+src/000_all.php:54 PhanPluginUnusedVariable Variable is never used: $four
+src/000_all.php:68 PhanPluginUnusedVariable Variable is never used: $five
+src/000_all.php:124 PhanPluginUnusedVariable Variable is never used: $six
+src/000_all.php:156 PhanPluginUnusedVariable Variable is never used: $seven
+src/000_all.php:167 PhanPluginUnusedVariable Variable is never used: $eight
+src/000_all.php:207 PhanPluginUnusedVariable Variable is never used: $nine
+src/000_all.php:251 PhanPluginUnusedVariable Variable is never used: $ten
+src/000_all.php:273 PhanPluginUnusedVariable Variable is never used: $eleven
+src/000_all.php:295 PhanPluginUnusedVariable Variable is never used: $twelwe
+src/000_all.php:318 PhanPluginUnusedVariable Variable is never used: $thirteen
+src/000_all.php:417 PhanPluginUnusedVariable Variable is never used: $fourteen
+src/000_all.php:438 PhanPluginUnusedMethodArgument Parameter is never used: $fifteen
+src/000_all.php:459 PhanPluginUnnecessaryReference $sixteen is a reference to $seventeen, but $seventeen is never used
+src/000_all.php:461 PhanPluginUnusedVariable Variable is never used: $sixteen
+src/000_all.php:495 PhanPluginUnnecessaryReference $eighteen is a reference to $nineteen, but $nineteen is never used
+src/001_func.php:7 PhanPluginUnusedVariable Variable is never used: $one
+src/001_func.php:8 PhanPluginUnusedVariable Variable is never used: $two
+src/001_func.php:25 PhanPluginUnusedMethodArgument Parameter is never used: $three
+src/002_closure.php:7 PhanPluginUnusedVariable Variable is never used: $one
+src/002_closure.php:8 PhanPluginUnusedVariable Variable is never used: $two
+src/002_closure.php:24 PhanPluginUnusedMethodArgument Parameter is never used: $three

--- a/tests/src/000_all.php
+++ b/tests/src/000_all.php
@@ -39,7 +39,7 @@ class testAssignedInControlStructure {
         if (true == 1) {
             $res = $t->sha1_verify($password, $hash);
         }
-        
+
         return ($res === $hash);
     }
 }
@@ -53,7 +53,7 @@ class testUnusedInControlStructure {
         if (true == 1) {
             $four = $t->sha1_verify($password, $hash);
         }
-        
+
         return ($password === $hash);
     }
 }
@@ -67,7 +67,7 @@ class testTrackAssignInControlStructure {
         if (true == 1) {
             $five = $t->sha1_verify($password, $hash);
         }
-        
+
         return ($password === $hash);
     }
 }
@@ -188,7 +188,7 @@ class testUseInMethodCall
             [$id]
         );
 
-        return $statement; 
+        return $statement;
     }
 }
 
@@ -199,7 +199,7 @@ class testForeachElseIf
     {
         $a = ['a', 'b', 'c'];
         $nine = ['a', 'b', 'c'];
-        
+
         foreach ($a as $b) {
             if (count($nine) == 1) {
                 $nine = array_shift($nine);
@@ -338,7 +338,7 @@ class testAssignmentInWhileCondition
         while ($row = $statement->fetch()) {
             $collection[] = $row;
         }
-        
+
         return $collection;
     }
 }
@@ -523,7 +523,7 @@ class testReferences
     public static function new(array $config)
     {
         $ret = new static;
-        
+
         // Loop sections and set false to everything
         foreach ($config as $secName => &$section) {
             foreach ($section['fields'] as &$confField) {
@@ -536,7 +536,7 @@ class testReferences
     }
 }
 
-// @todo 
+// @todo
 // class testIncremenetButNeverReturnedOrUsed {
 //     public function pub()
 //     {

--- a/tests/src/001_func.php
+++ b/tests/src/001_func.php
@@ -1,0 +1,29 @@
+<?php
+// Note: Functions, Methods, and Closures use the exact same code to check for unused parameters.
+// So, it's redundant to duplicate the tests. Just add a few tests to act as a sanity check.
+
+// this should fail on $one and $two
+function add(int $my_param):int {
+    $one = "hello world";
+    $two = $my_param;
+    $my_param+1;
+    return $my_param;
+}
+
+function sub(int $other_param) {
+    return $other_param;
+}
+
+// This should pass
+function sha1_verify($password, $hash)
+{
+    $shaHash = sha1($password);
+    return ($shaHash === $hash);
+}
+
+// This should fail on $three
+function sha1_verifyB($password, $hash, $three)
+{
+    $shaHash = sha1($password);
+    return ($shaHash === $hash);
+}

--- a/tests/src/002_closure.php
+++ b/tests/src/002_closure.php
@@ -26,3 +26,20 @@ $c = function($password, $hash, $three) {
     return ($shaHash === $hash);
 };
 $c('x', 'badhash', 'threeVal');
+
+// This should not fail on $unusedVar or $_
+$d = function($password, $_, $hash, $unusedVar) {
+    $shaHash = sha1($password);
+    return ($shaHash === $hash);
+};
+$d('x', null, 'badhash', 'unused');
+
+/**
+ * This should not fail on $extra
+ * @param string $extra @phan-unused-param
+ */
+$e = function($password, $hash, $extra) {
+    $shaHash = sha1($password);
+    return ($shaHash === $hash);
+};
+$e('x', 'badhash', 'unused');

--- a/tests/src/002_closure.php
+++ b/tests/src/002_closure.php
@@ -1,0 +1,28 @@
+<?php
+// Note: Functions, Methods, and Closures use the exact same code to check for unused parameters.
+// So, it's redundant to duplicate the tests. Just add a few tests to act as a sanity check.
+
+// this should fail on $one and $two
+(function (int $my_param):int {
+    $one = "hello world";
+    $two = $my_param;
+    $my_param+1;
+    return $my_param;
+})(3);
+
+(function (int $other_param) {
+    return $other_param;
+})(2);
+
+// This should pass
+(function($password, $hash) {
+    $shaHash = sha1($password);
+    return ($shaHash === $hash);
+})('hunter2', 'badhash');
+
+// This should fail on $three
+$c = function($password, $hash, $three) {
+    $shaHash = sha1($password);
+    return ($shaHash === $hash);
+};
+$c('x', 'badhash', 'threeVal');

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -9,7 +9,7 @@ echo "Running phan in '$PWD' ..."
 rm $ACTUAL_PATH -f
 ./../vendor/bin/phan | tee $ACTUAL_PATH
 # diff returns a non-zero exit code if files differ or are missing
-# This outputs the 
+# This outputs the difference between actual and expected output.
 echo
 echo "Comparing the output:"
 diff $EXPECTED_PATH $ACTUAL_PATH


### PR DESCRIPTION
Update to use recent versions of php-ast and phan. The dev version was used for running phan analysis

- Switch to a dependency on AST version 40
  - AST_LIST is no longer
    emitted by php-ast (both in php 7.0 and php 7.1)
    Also, AST_ARRAY started supporting short array syntax in php 7.1
    (E.g. `[$a, $b] = [$b, $a]`)

Switch to PluginV2, which is part of Phan 0.9.3+/0.8.5+

Clean up issues detected by phan, stricten annotations,

Prefer checks based on node kind, in places where there's only one
possible node kind.

add sanity tests that this plugin analyzes functions and closures.
These tests are based on tests of methods.

test.sh passes, and phan analysis passes