### PR TITLE
Fix bug checking a for loop with empty init statement

### DIFF
--- a/src/UnusedVariablePlugin.php
+++ b/src/UnusedVariablePlugin.php
@@ -475,7 +475,7 @@ class UnusedVariableVisitor extends PluginAwareAnalysisVisitor {
         $this->parseCond($assignments, $node, $instructionCount);
         $this->parseExpr($assignments, $node, $instructionCount);
 
-        if (\ast\AST_FOR === $node->kind) {
+        if (\ast\AST_FOR === $node->kind && isset($node->children['init'])) {
             $this->parseStmts(
                 $assignments,
                 $node->children['init'],

--- a/tests/expected/all_output.expected
+++ b/tests/expected/all_output.expected
@@ -31,3 +31,5 @@ src/006_references.php:104 PhanPluginUnusedVariable Variable is never used: $sec
 src/007_loops.php:18 PhanPluginUnusedVariable Variable is never used: $i
 src/007_loops.php:26 PhanPluginUnusedVariable Variable is never used: $k
 src/007_loops.php:26 PhanPluginUnusedVariable Variable is never used: $v
+src/007_loops.php:32 PhanPluginUnusedMethodArgument Parameter is never used: $start
+src/007_loops.php:33 PhanPluginUnusedVariable Variable is never used: $i

--- a/tests/src/007_loops.php
+++ b/tests/src/007_loops.php
@@ -27,3 +27,11 @@ function foreachloop007_1() {
         echo count($a);
     }
 }
+
+// Should not throw, should warn about $i and $start
+function forloop007_4(int $start) {
+    $i = 0;
+    for (; ; ) {
+        break;
+    }
+}


### PR DESCRIPTION
Check for empty for loop initialization statement to prevent an uncaught Error (`for (; condition; postStatement) {...}`)