### PR TITLE
Fix false positives about $this and superglobals such as $_SESSION

### DIFF
--- a/src/UnusedVariablePlugin.php
+++ b/src/UnusedVariablePlugin.php
@@ -7,6 +7,7 @@ use Phan\Analysis\BlockExitStatusChecker;
 use Phan\Exception\CodeBaseException;
 use Phan\Language\Context;
 use Phan\Language\Element\FunctionInterface;
+use Phan\Language\Element\Variable;
 use Phan\Language\UnionType;
 use Phan\PluginV2;
 use Phan\PluginV2\AnalyzeNodeCapability;
@@ -663,6 +664,11 @@ class UnusedVariableVisitor extends PluginAwareAnalysisVisitor {
 
         if (count($assignments) > 0) {
             foreach ($assignments as $param => $data) {
+                if (Variable::isSuperglobalVariableWithName($param) || $param === 'this') {
+                    // Don't warn about statements such as `$_SESSION['prop'] = $value`;
+                    // Don't warn about $this['prop'] = 'x' (for objects that implement ArrayAccess)
+                    continue;
+                }
                 if ($data['param'] === true) {
                     $shouldWarn = false;
                     if ($data['reference']) {

--- a/tests/expected/all_output.expected
+++ b/tests/expected/all_output.expected
@@ -33,3 +33,9 @@ src/007_loops.php:26 PhanPluginUnusedVariable Variable is never used: $k
 src/007_loops.php:26 PhanPluginUnusedVariable Variable is never used: $v
 src/007_loops.php:32 PhanPluginUnusedMethodArgument Parameter is never used: $start
 src/007_loops.php:33 PhanPluginUnusedVariable Variable is never used: $i
+src/016_globals.php:6 PhanPluginUnusedVariable Variable is never used: $_ENVNOTSUPERGLOBAL
+src/017_this.php:5 PhanPluginUnusedMethodArgument Parameter is never used: $key
+src/017_this.php:6 PhanPluginUnusedMethodArgument Parameter is never used: $key
+src/017_this.php:6 PhanPluginUnusedMethodArgument Parameter is never used: $value
+src/017_this.php:7 PhanPluginUnusedMethodArgument Parameter is never used: $key
+src/017_this.php:8 PhanPluginUnusedMethodArgument Parameter is never used: $key

--- a/tests/src/016_globals.php
+++ b/tests/src/016_globals.php
@@ -1,0 +1,7 @@
+<?php
+
+function testSuperglobal() {
+    $_SESSION['foo'] = 'bar';
+    $_ENV = ['envOverride' => 'bar'];
+    $_ENVNOTSUPERGLOBAL = ['x' =>'bar'];  // should warn
+}

--- a/tests/src/017_this.php
+++ b/tests/src/017_this.php
@@ -1,0 +1,15 @@
+<?php
+
+class X16 implements ArrayAccess {
+    // stub implementation
+    public function offsetGet($key) {return null;}
+    public function offsetSet($key, $value) {}
+    public function offsetExists($key) { return false;}
+    public function offsetUnset($key) {}
+
+    public function test() {
+        $this['x'] = 'y';  // should not warn
+    }
+}
+$x = new X16();
+$x->test();


### PR DESCRIPTION
Superglobals may be used later outside of the function call. 

`$this['x'] = expr;`is actually a call to offsetSet, different from other local variables (Reserved in php 7.1, I think)