### PR TITLE
Work on making this work in travis CI

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -127,7 +127,6 @@ return [
     // A list of plugin files to execute
     'plugins' => [
         'AlwaysReturnPlugin',
-        'DemoPlugin',
         'DollarDollarPlugin',
         'UnreachableCodePlugin',
         // NOTE: src/Phan/Language/Internal/FunctionSignatureMap.php mixes value without keys (as return type) with values having keys deliberately.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: php
+
+# PhanUnusedVariable can be used with any PHP version from 7.0 to 7.2.
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+
+sudo: false
+dist: trusty
+
+# Use a cache: Slightly speed up composer installation and building php-ast
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - $HOME/.cache/phan-ast/build
+
+# We invoke php multiple times via CLI in several tests, so enable the opcache file cache.
+before_install:
+  - ./tests/travis_setup.sh
+  #- composer validate # Skip because 'Name "mattriverm/PhanUnusedVariable" does not match the best practice (e.g. lower-cased/with-dashes).
+# Optional: --classmap-authoritative --prefer-dist makes running this test slightly faster,
+# and imitates phan's recommended settings
+install:
+  - composer --prefer-dist --classmap-authoritative install
+
+# TEST_SUITES contains 1 or more space-separated value for TEST_SUITE
+# We have a fake TEST_SUITE which runs phan, and check if the exit code is non-zero and the standard output is non-empty.
+# This is used instead of a unit test because Phan currently caches too much state for this to be run with other unit tests, and the configuration might end up different within a unit test.
+# This was moved into a separate script to stop cluttering up .travis.yml
+script:
+  # Self-analyze (Includes checks for unused variables)
+  - vendor/bin/phan
+  # Run the test suite
+  - cd tests; ./test.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # PhanUnusedVariable
+
 A plugin for phan/phan that tries to detect unused variables in class methods.
 
 ## Overview
@@ -14,4 +15,4 @@ $ composer install
 $ cd tests && sh test.sh
 ```
 
-Expected output is issues on variables $one to $nineteen and nothing else.
+A summary is printed at the bottom of the output comparing the actual output with the expected output.

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,12 @@
             "name": "Mattias Forsberg"
         }
     ],
+    "config": {
+        "sort-packages": true,
+        "platform": {
+            "php": "7.0.24"
+        }
+    },
     "require-dev": {
         "phan/phan": "^0.12.2"
     }

--- a/tests/travis_setup.sh
+++ b/tests/travis_setup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Source: https://github.com/phan/phan/blob/master/tests/travis_setup.sh
+# (with minor modifications)
+if [[ "x${TRAVIS:-}" == "x" ]]; then
+    echo "This should only be run in travis"
+    exit 1
+fi
+
+set -xeu
+
+# Ensure the build directory exist
+PHP_VERSION_ID=$(php -r "echo PHP_VERSION_ID . '_' . PHP_DEBUG . '_' . PHP_ZTS;")
+PHAN_BUILD_DIR="$HOME/.cache/phan-ast"
+EXPECTED_AST_FILE="$PHAN_BUILD_DIR/build/php-ast-$PHP_VERSION_ID.so"
+
+[[ -d "$PHAN_BUILD_DIR" ]] || mkdir -p "$PHAN_BUILD_DIR"
+
+cd "$PHAN_BUILD_DIR"
+
+if [[ ! -e "$EXPECTED_AST_FILE" ]]; then
+  echo "No cached extension found. Building..."
+  rm -rf php-ast build
+  mkdir build
+
+  git clone --depth 1 https://github.com/nikic/php-ast.git php-ast
+
+  export CFLAGS="-O3"
+  pushd php-ast
+  # Install the ast extension
+  phpize
+  ./configure
+  make
+
+  cp modules/ast.so "$EXPECTED_AST_FILE"
+  popd
+else
+  echo "Using cached extension."
+fi
+
+echo "extension=$EXPECTED_AST_FILE" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+
+php -r 'function_exists("ast\parse_code") || (print("Failed to enable php-ast\n") && exit(1));'
+
+# Disable xdebug, since we aren't currently gathering code coverage data and
+# having xdebug slows down Composer a bit.
+phpenv config-rm xdebug.ini


### PR DESCRIPTION
composer.json only matters for running the unit tests.
This plugin is a standalone file.

Add a build status, update the test documentation

- Pin the PHP version to emulate for composer installation,
  making it easy to switch between versions to run tests.

Remove DemoPlugin, it doesn't do anything, and was just in the Phan
config this is based on to verify that plugin capabilities work.

(You'd have to log in to https://travis-ci.org/ and enable travis for this project)