### PR TITLE
Minor fixes

### DIFF
--- a/src/UnusedVariablePlugin.php
+++ b/src/UnusedVariablePlugin.php
@@ -935,6 +935,14 @@ class UnusedVariableVisitor extends PluginAwarePostAnalysisVisitor {
      */
     private function getIssueNameForMethodNode(Node $node, Context $context) : string
     {
+        switch ($node->kind) {
+            case \ast\AST_FUNC_DECL:
+                return "PhanPluginUnusedGlobalFunctionArgument";
+            case \ast\AST_CLOSURE:
+                return "PhanPluginUnusedClosureArgument";
+            default:
+                break;
+        }
         $fields = '';
         $flags = $node->flags;
         if (($flags & ast\flags\MODIFIER_PRIVATE) !== 0) {

--- a/tests/expected/all_output.expected
+++ b/tests/expected/all_output.expected
@@ -46,3 +46,4 @@ src/017_this.php:8 PhanPluginUnusedPublicMethodArgument Parameter is never used:
 src/018_raii.php:10 PhanPluginUnusedVariable Variable is never used: $value
 src/019_final.php:4 PhanPluginUnusedPublicFinalMethodArgument Parameter is never used: $arg
 src/019_final.php:9 PhanPluginUnusedProtectedFinalMethodArgument Parameter is never used: $arg
+src/020_crash.php:20 PhanPluginUnusedVariable Variable is never used: $key

--- a/tests/expected/all_output.expected
+++ b/tests/expected/all_output.expected
@@ -19,11 +19,11 @@ src/000_all.php:475 PhanPluginUnusedVariable Variable is never used: $a
 src/001_func.php:7 PhanPluginUnusedVariable Variable is never used: $one
 src/001_func.php:8 PhanPluginUnusedVariable Variable is never used: $two
 src/001_func.php:9 PhanNoopBinaryOperator Unused result of a binary '+' operator
-src/001_func.php:25 PhanPluginUnusedPublicMethodArgument Parameter is never used: $three
+src/001_func.php:25 PhanPluginUnusedGlobalFunctionArgument Parameter is never used: $three
 src/002_closure.php:7 PhanPluginUnusedVariable Variable is never used: $one
 src/002_closure.php:8 PhanPluginUnusedVariable Variable is never used: $two
 src/002_closure.php:9 PhanNoopBinaryOperator Unused result of a binary '+' operator
-src/002_closure.php:24 PhanPluginUnusedPublicMethodArgument Parameter is never used: $three
+src/002_closure.php:24 PhanPluginUnusedClosureArgument Parameter is never used: $three
 src/005_static_variables.php:24 PhanPluginUnusedVariable Variable is never used: $initialized
 src/006_references.php:14 PhanPluginUnusedPublicMethodArgument Parameter is never used: $fifteen
 src/006_references.php:35 PhanPluginUnnecessaryReference $sixteen is a reference to $seventeen, but $seventeen is never used
@@ -33,7 +33,7 @@ src/006_references.php:104 PhanPluginUnusedVariable Variable is never used: $sec
 src/007_loops.php:18 PhanPluginUnusedVariable Variable is never used: $i
 src/007_loops.php:26 PhanPluginUnusedVariable Variable is never used: $k
 src/007_loops.php:26 PhanPluginUnusedVariable Variable is never used: $v
-src/007_loops.php:32 PhanPluginUnusedPublicMethodArgument Parameter is never used: $start
+src/007_loops.php:32 PhanPluginUnusedGlobalFunctionArgument Parameter is never used: $start
 src/007_loops.php:33 PhanPluginUnusedVariable Variable is never used: $i
 src/013_closure.php:10 PhanPluginUnusedClosureUseArgument Closure use variable is never used: $c
 src/013_closure_simple.php:6 PhanPluginUnusedClosureUseArgument Closure use variable is never used: $c

--- a/tests/src/020_crash.php
+++ b/tests/src/020_crash.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @suppress PhanTypeExpectedObjectPropAccess
+ * @suppress PhanTypeMismatchDimFetch
+ * Suppressing issues that aren't emitted by this plugin. See https://github.com/phan/phan/issues/1601
+ */
+function example() {
+    $fields = ['key' => 'value'];
+    $x = [];
+    $o = new stdClass();
+    foreach ($fields as $x['field'] => $o->propName) {
+        var_export($x);
+        var_export($o);
+    }
+    foreach ($fields as $o->propName2 => $x['field2']) {
+        var_export($x);
+        var_export($o);
+    }
+    foreach ($fields as $key => $x['field2']) {
+        var_export($x);
+    }
+}


### PR DESCRIPTION
Use distinct issue types for unused closure/global function params, to make it easier to independently suppress those

Fixed a crash when a array/property access was used in the key/value of a foreach